### PR TITLE
The database password needs to be setup

### DIFF
--- a/backend_app/backend_app/settings.py.sample
+++ b/backend_app/backend_app/settings.py.sample
@@ -184,7 +184,7 @@ DATABASES = {
         'ENGINE': 'django.db.backends.postgresql',
         'NAME': os.environ.get('POSTGRES_DBNAME', 'patrowlhears_db'),
         'USER': os.environ.get('POSTGRES_USER', 'patrowlhears'),
-        'PASSWORD': os.environ.get('POSTGRES_PASSWORD', ''),
+        'PASSWORD': os.environ.get('POSTGRES_PASSWORD', 'patrowlhears'),
         'HOST': os.environ.get('POSTGRES_HOST', 'localhost'),
         'PORT': os.environ.get('POSTGRES_PORT', ''),
     },


### PR DESCRIPTION
Fix the issue where Django can't connect to the database in the auto install script : 

```
The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/debian/PatrowlHears-master/backend_app/manage.py", line 21, in <module>
    main()
  File "/home/debian/PatrowlHears-master/backend_app/manage.py", line 17, in main
    execute_from_command_line(sys.argv)
  File "/home/debian/PatrowlHears-master/backend_app/env/lib/python3.9/site-packages/django/core/management/__init__.py", line 401, in execute_from_command_line
    utility.execute()
  File "/home/debian/PatrowlHears-master/backend_app/env/lib/python3.9/site-packages/django/core/management/__init__.py", line 395, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/debian/PatrowlHears-master/backend_app/env/lib/python3.9/site-packages/django/core/management/base.py", line 330, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/debian/PatrowlHears-master/backend_app/env/lib/python3.9/site-packages/django/core/management/base.py", line 371, in execute
    output = self.handle(*args, **options)
  File "/home/debian/PatrowlHears-master/backend_app/env/lib/python3.9/site-packages/django/core/management/commands/loaddata.py", line 71, in handle
    with transaction.atomic(using=self.using):
  File "/home/debian/PatrowlHears-master/backend_app/env/lib/python3.9/site-packages/django/db/transaction.py", line 175, in __enter__
    if not connection.get_autocommit():
  File "/home/debian/PatrowlHears-master/backend_app/env/lib/python3.9/site-packages/django/db/backends/base/base.py", line 389, in get_autocommit
    self.ensure_connection()
  File "/home/debian/PatrowlHears-master/backend_app/env/lib/python3.9/site-packages/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
  File "/home/debian/PatrowlHears-master/backend_app/env/lib/python3.9/site-packages/django/db/backends/base/base.py", line 219, in ensure_connection
    self.connect()
  File "/home/debian/PatrowlHears-master/backend_app/env/lib/python3.9/site-packages/django/db/utils.py", line 90, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/home/debian/PatrowlHears-master/backend_app/env/lib/python3.9/site-packages/django/db/backends/base/base.py", line 219, in ensure_connection
    self.connect()
  File "/home/debian/PatrowlHears-master/backend_app/env/lib/python3.9/site-packages/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
  File "/home/debian/PatrowlHears-master/backend_app/env/lib/python3.9/site-packages/django/db/backends/base/base.py", line 200, in connect
    self.connection = self.get_new_connection(conn_params)
  File "/home/debian/PatrowlHears-master/backend_app/env/lib/python3.9/site-packages/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
  File "/home/debian/PatrowlHears-master/backend_app/env/lib/python3.9/site-packages/django/db/backends/postgresql/base.py", line 187, in get_new_connection
    connection = Database.connect(**conn_params)
  File "/home/debian/PatrowlHears-master/backend_app/env/lib/python3.9/site-packages/psycopg2/__init__.py", line 122, in connect
    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
django.db.utils.OperationalError: fe_sendauth: no password supplied
```